### PR TITLE
feat(ci): drop Node.js v10 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "author": "Kenan Yildirim <kenan@kenany.me> (https://kenany.me/)",
   "engines": {
-    "node": "10 || 12 || 14 || >=16"
+    "node": "12 || 14 || >=16"
   },
   "main": "index.js",
   "files": [


### PR DESCRIPTION
BREAKING CHANGE: Node.js v10 is no longer supported.